### PR TITLE
Add server info view to the root path /

### DIFF
--- a/billy/api/__init__.py
+++ b/billy/api/__init__.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 
 def includeme(config):
+    config.add_route('server_info', '/')
+
     config.include('.company', route_prefix='/v1')
     config.include('.customer', route_prefix='/v1')
     config.include('.plan', route_prefix='/v1')

--- a/billy/api/server_info.py
+++ b/billy/api/server_info.py
@@ -1,0 +1,20 @@
+from __future__ import unicode_literals
+
+from pyramid.view import view_config
+
+from billy.utils.generic import get_git_rev
+
+
+@view_config(route_name='server_info', 
+             request_method='GET', 
+             renderer='json')
+def server_info(request):
+    """Get server info
+
+    """
+    # TODO: get some more useful information here, such as the date time
+    # of last yield transaction?
+    return dict(
+        server='Billy - The recurring payment server powered by Balanced',
+        revision=get_git_rev(),
+    )

--- a/billy/api/server_info.py
+++ b/billy/api/server_info.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from pyramid.view import view_config
 
+from billy.models.transaction import TransactionModel
 from billy.utils.generic import get_git_rev
 
 
@@ -9,12 +10,17 @@ from billy.utils.generic import get_git_rev
              request_method='GET', 
              renderer='json')
 def server_info(request):
-    """Get server info
+    """Get server information
 
     """
-    # TODO: get some more useful information here, such as the date time
-    # of last yield transaction?
+    tx_model = TransactionModel(request.session)
+    last_transaction = tx_model.get_last_transaction()
+    last_transaction_dt = None
+    if last_transaction is not None:
+        last_transaction_dt = last_transaction.created_at.isoformat()
     return dict(
-        server='Billy - The recurring payment server powered by Balanced',
+        server='Billy - The recurring payment server',
+        powered_by='BalancedPayments.com',
         revision=get_git_rev(),
+        last_transaction_created_at=last_transaction_dt,
     )

--- a/billy/models/transaction.py
+++ b/billy/models/transaction.py
@@ -45,6 +45,17 @@ class TransactionModel(BaseTableModel):
         STATUS_CANCELED,
     ]
 
+    def get_last_transaction(self):
+        """Get last transaction
+
+        """
+        query = (
+            self.session
+            .query(tables.Transaction)
+            .order_by(tables.Transaction.created_at.desc())
+        )
+        return query.first()
+
     @decorate_offset_limit
     def list_by_company_guid(self, company_guid):
         """Get transactions of a company by given guid

--- a/billy/tests/functional/test_server_info.py
+++ b/billy/tests/functional/test_server_info.py
@@ -1,0 +1,14 @@
+from __future__ import unicode_literals
+
+from billy.tests.functional.helper import ViewTestCase
+
+
+class TestServerInfo(ViewTestCase):
+
+    def make_one(self):
+        from billy.api.auth import get_remote_user
+        return get_remote_user
+
+    def test_server_info(self):
+        res = self.testapp.get('/', status=200)
+        self.assertIn('revision', res.json)

--- a/billy/tests/functional/test_server_info.py
+++ b/billy/tests/functional/test_server_info.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+import datetime
+
+import transaction as db_transaction
 
 from billy.tests.functional.helper import ViewTestCase
 
@@ -12,3 +15,47 @@ class TestServerInfo(ViewTestCase):
     def test_server_info(self):
         res = self.testapp.get('/', status=200)
         self.assertIn('revision', res.json)
+
+    def test_server_info_with_transaction(self):
+        from billy.models.company import CompanyModel
+        from billy.models.customer import CustomerModel
+        from billy.models.plan import PlanModel
+        from billy.models.subscription import SubscriptionModel
+        from billy.models.transaction import TransactionModel
+
+        company_model = CompanyModel(self.testapp.session)
+        customer_model = CustomerModel(self.testapp.session)
+        plan_model = PlanModel(self.testapp.session)
+        subscription_model = SubscriptionModel(self.testapp.session)
+        transaction_model = TransactionModel(self.testapp.session)
+
+        with db_transaction.manager:
+            company_guid = company_model.create(
+                processor_key='MOCK_PROCESSOR_KEY',
+            )
+            customer_guid = customer_model.create(
+                company_guid=company_guid
+            )
+            plan_guid = plan_model.create(
+                company_guid=company_guid,
+                frequency=plan_model.FREQ_WEEKLY,
+                plan_type=plan_model.TYPE_CHARGE,
+                amount=10,
+            )
+            subscription_guid = subscription_model.create(
+                customer_guid=customer_guid,
+                plan_guid=plan_guid,
+            )
+            transaction_guid = transaction_model.create(
+                subscription_guid=subscription_guid,
+                transaction_type=transaction_model.TYPE_CHARGE,
+                amount=10,
+                payment_uri='/v1/cards/tester',
+                scheduled_at=datetime.datetime.utcnow(),
+            )
+
+        transaction = transaction_model.get(transaction_guid)
+
+        res = self.testapp.get('/', status=200)
+        self.assertEqual(res.json['last_transaction_created_at'], 
+                         transaction.created_at.isoformat())

--- a/billy/tests/unit/test_models/test_transaction.py
+++ b/billy/tests/unit/test_models/test_transaction.py
@@ -893,3 +893,20 @@ class TestTransactionModel(ModelTestCase):
             tx_guids = model.process_transactions(processor)
 
         self.assertEqual(set(tx_guids), set([guid1, guid2, guid3]))
+
+    def test_get_last_transaction(self):
+        model = self.make_one(self.session)
+
+        guids = []
+        for dt in ['2013-08-17', '2013-08-15', '2013-08-15']:
+            with freeze_time(dt):
+                with db_transaction.manager:
+                    guid = model.create(
+                        subscription_guid=self.subscription_guid,
+                        transaction_type=model.TYPE_CHARGE,
+                        amount=10,
+                        payment_uri='/v1/cards/tester',
+                        scheduled_at=datetime.datetime.utcnow(),
+                    )
+                    guids.append(guid)
+        self.assertEqual(model.get_last_transaction().guid, guids[0])

--- a/billy/tests/unit/test_utils/test_generic.py
+++ b/billy/tests/unit/test_utils/test_generic.py
@@ -49,3 +49,31 @@ class TestGenericUtils(unittest.TestCase):
         assert_round_down('0.5566', '0.55')
         assert_round_down('0.7788', '0.77')
         assert_round_down('1.23456789', '1.23')
+
+    def test_get_git_rev(self):
+        import os
+        import tempfile
+        from billy.utils.generic import get_git_rev
+        temp_dir = tempfile.mkdtemp()
+
+        git_dir = os.path.join(temp_dir, '.git')
+        head_file = os.path.join(git_dir, 'HEAD')
+        refs_dir = os.path.join(git_dir, 'refs')
+        heads_dir = os.path.join(refs_dir, 'heads')
+        master_file = os.path.join(heads_dir, 'master')
+
+        os.mkdir(git_dir)
+        os.mkdir(refs_dir)
+        os.mkdir(heads_dir)
+
+        with open(head_file, 'wt') as f:
+            f.write('ref: refs/heads/master')
+
+        with open(master_file, 'wt') as f:
+            f.write('DUMMY_REV')
+
+        self.assertEqual(get_git_rev(temp_dir), 'DUMMY_REV')
+
+        rev = get_git_rev()
+        self.assertNotEqual(rev, None)
+        self.assertEqual(len(rev), 40)

--- a/billy/tests/unit/test_utils/test_generic.py
+++ b/billy/tests/unit/test_utils/test_generic.py
@@ -77,3 +77,10 @@ class TestGenericUtils(unittest.TestCase):
         rev = get_git_rev()
         self.assertNotEqual(rev, None)
         self.assertEqual(len(rev), 40)
+
+        # sometimes it would be a hash revision value there rahter than
+        # ref: /path/to/ref
+        with open(head_file, 'wt') as f:
+            f.write('DUMMY_HASH_REV')
+
+        self.assertEqual(get_git_rev(temp_dir), 'DUMMY_HASH_REV')

--- a/billy/utils/generic.py
+++ b/billy/utils/generic.py
@@ -63,3 +63,22 @@ def round_down_cent(amount):
     :return: the rounded money amount
     """
     return amount.quantize(decimal.Decimal('.01'), rounding=decimal.ROUND_DOWN)
+
+
+def get_git_rev(project_dir=None):
+    """Get current GIT reversion if it is available, otherwise, None is 
+    returned
+
+    """
+    if project_dir is None:
+        import billy
+        pkg_dir = os.path.dirname(billy.__file__)
+        project_dir, _ = os.path.split(pkg_dir)
+    git_dir = os.path.join(project_dir, '.git')
+    head_file = os.path.join(git_dir, 'HEAD')
+    with open(head_file, 'rt') as f:
+        content = f.read().strip()
+    ref_file = os.path.join(git_dir, content[5:])
+    with open(ref_file, 'rt') as f:
+        rev = f.read().strip()
+    return rev

--- a/billy/utils/generic.py
+++ b/billy/utils/generic.py
@@ -78,7 +78,9 @@ def get_git_rev(project_dir=None):
     head_file = os.path.join(git_dir, 'HEAD')
     with open(head_file, 'rt') as f:
         content = f.read().strip()
-    ref_file = os.path.join(git_dir, content[5:])
-    with open(ref_file, 'rt') as f:
-        rev = f.read().strip()
-    return rev
+    if content.startswith('ref: '):
+        ref_file = os.path.join(git_dir, content[5:])
+        with open(ref_file, 'rt') as f:
+            rev = f.read().strip()
+        return rev
+    return content


### PR DESCRIPTION
As there is nothing at root path / for API server, when people connected to it they will see a 404 page. Currently, there is no a easy way to check whether the server is running other than calling the API, so I think it is better to add a server information view at the root path. This could clear the doubt.
